### PR TITLE
Update logsearch manifests to use logsearch-for-cloudfoundry-v1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem 'bosh-workspace', git: 'https://github.com/cloudfoundry-incubator/bosh-workspace.git', :branch => 'deployment-patch'
+gem 'bosh-workspace', '~> 0.9.0.rc3'
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,38 +1,33 @@
-GIT
-  remote: https://github.com/cloudfoundry-incubator/bosh-workspace.git
-  revision: 4e49de6b1d42cb824d05e1ddec37bab912d55f47
-  branch: deployment-patch
-  specs:
-    bosh-workspace (0.8.4)
-      bosh_cli (>= 1.2682.0)
-      bosh_common (>= 1.2682.0)
-      hashdiff (~> 0.2.1)
-      membrane (~> 1.1.0)
-      rugged (~> 0.22.0b5)
-      semi_semantic (~> 1.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.0)
+    CFPropertyList (2.3.1)
     aws-sdk (1.60.2)
       aws-sdk-v1 (= 1.60.2)
     aws-sdk-v1 (1.60.2)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    blobstore_client (1.2852.0)
+    blobstore_client (1.2905.0)
       aws-sdk (= 1.60.2)
-      bosh_common (~> 1.2852.0)
+      bosh_common (~> 1.2905.0)
       fog (~> 1.27.0)
       httpclient (= 2.4.0)
       multi_json (~> 1.1)
       ruby-atmos-pure (~> 1.0.5)
-    bosh-template (1.2852.0)
+    bosh-template (1.2905.0)
       semi_semantic (~> 1.1.0)
-    bosh_cli (1.2852.0)
-      blobstore_client (~> 1.2852.0)
-      bosh-template (~> 1.2852.0)
-      bosh_common (~> 1.2852.0)
+    bosh-workspace (0.9.0.rc3)
+      bosh_cli (>= 1.2905.0)
+      bosh_common (>= 1.2905.0)
+      hashdiff (~> 0.2.1)
+      membrane (~> 1.1.0)
+      rugged (~> 0.23.0b1)
+      semi_semantic (~> 1.1.0)
+    bosh_cli (1.2905.0)
+      blobstore_client (~> 1.2905.0)
+      bosh-template (~> 1.2905.0)
+      bosh_common (~> 1.2905.0)
+      cf-uaa-lib (~> 3.2.1)
       highline (~> 1.6.2)
       httpclient (= 2.4.0)
       json_pure (~> 1.7)
@@ -43,11 +38,13 @@ GEM
       netaddr (~> 1.5.0)
       progressbar (~> 0.9.0)
       terminal-table (~> 1.4.3)
-    bosh_common (1.2852.0)
+    bosh_common (1.2905.0)
       logging (~> 1.8.2)
       semi_semantic (~> 1.1.0)
     builder (3.2.2)
-    excon (0.44.2)
+    cf-uaa-lib (3.2.1)
+      multi_json
+    excon (0.45.1)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
     fog (1.27.0)
@@ -72,7 +69,7 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.1.0)
+    fog-aws (0.1.1)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -93,7 +90,7 @@ GEM
       fog-xml
     fog-json (1.0.0)
       multi_json (~> 1.0)
-    fog-profitbricks (0.0.1)
+    fog-profitbricks (0.0.2)
       fog-core
       fog-xml
       nokogiri
@@ -143,7 +140,7 @@ GEM
     mime-types (2.4.3)
     mini_portile (0.6.2)
     minitar (0.5.4)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
@@ -159,7 +156,7 @@ GEM
       log4r (>= 1.1.9)
       ruby-hmac (>= 0.4.0)
     ruby-hmac (0.4.0)
-    rugged (0.22.0b5)
+    rugged (0.23.0b1)
     semi_semantic (1.1.0)
     terminal-table (1.4.5)
 
@@ -168,5 +165,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bosh-workspace!
+  bosh-workspace (~> 0.9.0.rc3)
   rake

--- a/deployments/logsearch-aws-vpc-cf-route.yml
+++ b/deployments/logsearch-aws-vpc-cf-route.yml
@@ -1,13 +1,10 @@
 ---
 name: logsearch-aws-vpc
-director_uuid: 0229c47f-e28c-470b-adf8-653e4cf00978
+director_uuid: current
 releases:
 - name: logsearch
-  version: latest
+  version: 18
   git: https://github.com/logsearch/logsearch-boshrelease.git
-- name: logsearch-for-cloudfoundry
-  version: latest
-  git: https://github.com/logsearch/logsearch-for-cloudfoundry.git
 - name: route-registrar
   version: latest
   git: https://github.com/cloudfoundry-community/route-registrar-boshrelease.git
@@ -28,13 +25,13 @@ meta:
   environment: logsearch-aws-vpc
   zones:
     z1:
-      ipmask: 10.10.5
-      subnet_id: subnet-93d332ca
-      az: us-west-1b
-  security_groups: [cf-0-vpc-aa77b9cf]
+      ipmask: 10.10.6
+      subnet_id: SUBNET_ID
+      az: us-west-2a
+  security_groups: [CLOUDFOUNDRY_SG]
   cf:
-    domain: 54.183.203.97.xip.io
+    domain: PUBLICIP.xip.io
     nats_servers:
-      - host: 10.10.3.10:4222
+      - host: 10.10.3.6:4222
         user: nats
         password: c1oudc0w

--- a/deployments/logsearch-aws-vpc-cf-route.yml
+++ b/deployments/logsearch-aws-vpc-cf-route.yml
@@ -1,10 +1,13 @@
 ---
 name: logsearch-aws-vpc
-director_uuid: current
+director_uuid: 0229c47f-e28c-470b-adf8-653e4cf00978
 releases:
 - name: logsearch
-  version: 18
+  version: latest
   git: https://github.com/logsearch/logsearch-boshrelease.git
+- name: logsearch-for-cloudfoundry
+  version: latest
+  git: https://github.com/logsearch/logsearch-for-cloudfoundry.git
 - name: route-registrar
   version: latest
   git: https://github.com/cloudfoundry-community/route-registrar-boshrelease.git
@@ -25,13 +28,13 @@ meta:
   environment: logsearch-aws-vpc
   zones:
     z1:
-      ipmask: 10.10.6
-      subnet_id: SUBNET_ID
-      az: us-west-2a
-  security_groups: [CLOUDFOUNDRY_SG]
+      ipmask: 10.10.5
+      subnet_id: subnet-93d332ca
+      az: us-west-1b
+  security_groups: [cf-0-vpc-aa77b9cf]
   cf:
-    domain: PUBLICIP.xip.io
+    domain: 54.183.203.97.xip.io
     nats_servers:
-      - host: 10.10.3.6:4222
+      - host: 10.10.3.10:4222
         user: nats
         password: c1oudc0w

--- a/templates/logsearch/jobs.yml
+++ b/templates/logsearch/jobs.yml
@@ -34,7 +34,8 @@ jobs:
 - name: ingestor
   release: logsearch
   templates:
-  - name: ingestor_lumberjack
+  - name: ingestor_cloudfoundry-firehose
+    release: logsearch-for-cloudfoundry
   - name: ingestor_syslog
   - name: ingestor_relp
   instances: (( merge ))

--- a/templates/logsearch/logstash-filters.yml
+++ b/templates/logsearch/logstash-filters.yml
@@ -2,36 +2,121 @@ properties:
   logstash_parser:
     filters: |
       <%=      # Parse Cloud Foundry logs from loggregator (syslog)
-      # see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
+      # see https://github.      com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
       
-      if [@type] in ["syslog", "relp"] and [@source.host] == "loggregator" {
+      if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
+        # Parse Cloud Foundry logs from doppler (via https://github.com/SpringerPE/firehose-to-syslog)
+        
+        json {
+            source => 'syslog_message'
+            add_tag => [ 'cloudfoundry_doppler' ] #This is only added if json parsing is successful
+        }
+        
+        if "_jsonparsefailure" in [tags] {
+            
+            # Amend the failure tag to match our fail/${addon}/${filter}/${detail} standard 
+            mutate {
+                add_tag => ["fail/cloudfoundry/doppler/jsonparsefailure_of_syslog_message"]
+                remove_tag => ["_jsonparsefailure"]
+            }
+        
+        } else {
+        
+            date {
+                match => [ "time", "ISO8601" ]
+            }
+        
+            if ('RTR' in [source_type]) {
+                grok {
+                    match => {
+                        'msg' => '%{HOSTNAME:hostname} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:verb} %{URIPATHPARAM:path} %{PROG:http_spec}\" %{BASE10NUM:status:int} %{BASE10NUM:body_bytes_sent:int} \"%{GREEDYDATA:referer}\" \"%{GREEDYDATA:http_user_agent}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:x_forwarded_for}\" vcap_request_id:%{NOTSPACE:vcap_request_id} response_time:%{NUMBER:response_time:float} app_id:%{NOTSPACE}'
+                        overwrite => [ "time" ]
+                        'tag_on_failure' => [ 'fail/cloudfoundry/doppler/RTR' ]
+                    }
+                }
+        
+                if !("fail/cloudfoundry/doppler/RTR" in [tags]) {
+                    date {
+                        match => [ "time", "dd/MM/y:HH:mm:ss Z" ]
+                    }
+                    if [x_forwarded_for] {
+                        mutate {
+                            gsub => ["x_forwarded_for","[\s\\"]",""] # remove quotes and whitespace
+                            split => ["x_forwarded_for", ","] # format is client, proxy1, proxy2 ...
+                        }
+        
+                       mutate {
+                          add_field => ["remote_addr", "%{x_forwarded_for[0]}"]
+                       }
+                                    
+                       geoip {
+                         source => "remote_addr"
+                       }
+                    }
+        
+                    mutate {
+                        remove => [ "msg" ]
+                    }
+                }
+            }
+        
+            #Ensure that we always have an event_type, in prep for adding metrics
+            if ![event_type] {
+                mutate {
+                    add_field => [ "event_type", "LogMessage" ]
+                }
+            }
+        
+            mutate {
+                remove_field => "@type"
+            }
+        
+            mutate {
+                add_field => [ "@type", "cloudfoundry_doppler" ]
+                rename => [ "syslog_message", "@message" ]
+                remove_field => "time"
+                remove_field => "syslog_severity_code"
+                remove_field => "syslog_facility_code"
+                remove_field => "syslog_facility"
+                remove_field => "syslog_severity"
+                remove_field => "syslog_pri"
+                remove_field => "syslog_program"
+                remove_field => "syslog_pid"
+            }
+        }
+        
+        
+            
+      } else if [@type] in ["syslog", "relp"] and [@source.host] == "loggregator" {
         # Parse Cloud Foundry logs from loggregator (syslog)
-        # see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
+        # see https://github.      com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
         
         grok {
-            match => { "syslog_message" => "\[(?<log_source>[^/\]]+)(?:/(?<log_source_id>[^\]]+))?\] \- \-(?: %{GREEDYDATA:message})?" }
+            match => { "syslog_procid" => "\[(?<log_source>[^/\]]+)(?:/(?<log_source_id>[^\]]+))?\]" }
             tag_on_failure => [
-                "_grokparsefailure-cf-loggregator"
+                "fail/logsearch-for-cloudfoundry/loggregator/_grokparsefailure"
             ]
         }
         
-        if !("_grokparsefailure-cf-loggregator" in [tags]) {
-            if [message] =~ /^\s*{".*}\s*$/ {
-                mutate {
-                    rename => [ "message", "_message_json" ]
-                }
-        
+        if !("fail/logsearch-for-cloudfoundry/loggregator/_grokparsefailure" in [tags]) {
+            #If it looks like JSON, it must be JSON...
+            if [syslog_message] =~ /^\s*{".*}\s*$/ {
                 json {
-                    source => "_message_json"
+                    source => "syslog_message"
                 }
         
                 # @todo seems like some messages have @timestamp in them? seems ci-specific
                 date {
                     match => [ "@timestamp", "ISO8601" ]
                 }
-        
+            } else {
                 mutate {
-                    remove_field => [ "_message_json" ]
+                    add_field => [ "message", "%{syslog_message}" ]
+                } 
+                if [message] == "-" {
+                    mutate {
+                        remove_field => "message"
+                    } 
                 }
             }
         
@@ -55,7 +140,7 @@ properties:
         # Parse Cloud Foundry logs from syslog_aggregator
         
         grok {
-            match => { "syslog_message" => "(?:\[job=%{NOTSPACE:@job.name}|-) +(?:index=%{NOTSPACE:@job.index}\]|-) %{GREEDYDATA:_message_json}" }
+            match => { "syslog_message" => "(?:\[job=%{NOTSPACE:@job.name}|-) +(?:index=%{NOTSPACE:@job.index}\]|-)       %{GREEDYDATA:_message_json}" }
             tag_on_failure => [
                 "_grokparsefailure-cf-vcap"
             ]
@@ -110,3 +195,4 @@ properties:
         }
       
       }
+      

--- a/templates/logsearch/logstash-filters.yml
+++ b/templates/logsearch/logstash-filters.yml
@@ -2,7 +2,7 @@ properties:
   logstash_parser:
     filters: |
       <%=      # Parse Cloud Foundry logs from loggregator (syslog)
-      # see https://github.      com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
+      # see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
       
       if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
         # Parse Cloud Foundry logs from doppler (via https://github.com/SpringerPE/firehose-to-syslog)
@@ -29,8 +29,8 @@ properties:
             if ('RTR' in [source_type]) {
                 grok {
                     match => {
-                        'msg' => '%{HOSTNAME:hostname} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:verb} %{URIPATHPARAM:path} %{PROG:http_spec}\" %{BASE10NUM:status:int} %{BASE10NUM:body_bytes_sent:int} \"%{GREEDYDATA:referer}\" \"%{GREEDYDATA:http_user_agent}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:x_forwarded_for}\" vcap_request_id:%{NOTSPACE:vcap_request_id} response_time:%{NUMBER:response_time:float} app_id:%{NOTSPACE}'
-                        overwrite => [ "time" ]
+                        'msg' => '%{HOSTNAME:hostname} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:verb} %{URIPATHPARAM:path} %{PROG:http_spec}\" %{BASE10NUM:status:int} %{BASE10NUM:body_bytes_sent:int} \"%{GREEDYDATA:referer}\" \"%{GREEDYDATA:http_user_agent}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:x_forwarded_for}\" vcap_request_id:%{NOTSPACE:vcap_request_id} response_time:%{NUMBER:response_time:float} app_id:%{NOTSPACE}' 
+                         overwrite => [ "time" ]
                         'tag_on_failure' => [ 'fail/cloudfoundry/doppler/RTR' ]
                     }
                 }
@@ -58,6 +58,25 @@ properties:
                         remove => [ "msg" ]
                     }
                 }
+            }
+        
+            #EXPERIMENTAL: Decorate log event with app name / space / org metadata
+            translate {
+                #Lookup using: cf curl "/v2/apps/$APP_UUID?inline-relations-depth=2" | jq --compact-output '. | { cf_app_id: .metadata.guid,       cf_app_name: .entity.name , cf_space_id: .entity.space.metadata.guid , cf_space_name: .entity.space.entity.name , cf_org_id:       .entity.space.entity.organization.metadata.guid , cf_org_name: .entity.space.entity.organization.entity.name }'
+                dictionary => [ 
+                    'ec2d33f6-fd1c-49a5-9a90-031454d1f1ac', '{"cf_app_id":"ec2d33f6-fd1c-49a5-9a90-      031454d1f1ac","cf_app_name":"myappname","cf_space_id":"ec2d33f6-fd1c-49a5-9a90-      03145444444","cf_space_name":"myspacename","cf_org_id":"ec2d33f6-fd1c-49a5-9a90-      031454d555555","cf_org_name":"myorgname"}',
+                    'afc7d161-b5d5-44f2-a2c8-63870ff8f2db', '{"cf_app_id":"afc7d161-b5d5-44f2-a2c8-      63870ff8f2db","cf_app_name":"goexample","cf_space_id":"b1aa14ec-eaae-4e2c-804d-      08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
+                    'abfc9a95-d20c-44bb-9771-4aba27856843', '{"cf_app_id":"abfc9a95-d20c-44bb-9771-4aba27856843","cf_app_name":"cf-      env","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-      e3a5db9419fd","cf_org_name":"system"}',
+                    'e6f78bd9-ca15-42d3-894e-d2b8b06e5e83', '{"cf_app_id":"e6f78bd9-ca15-42d3-894e-      d2b8b06e5e83","cf_app_name":"discourse","cf_space_id":"b1aa14ec-eaae-4e2c-804d-      08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}'
+                
+                ]
+                fallback => '{"cf_app_id_unknown":"00000000-0000-0000-0000-000000000000","cf_app_name":"UNKNOWN","cf_space_id":"00000000-0000      -0000-0000-000000000000","cf_space_name":"UNKNOWN","cf_org_id":"00000000-0000-0000-0000-      000000000000","cf_org_name":"UNKNOWN"}'
+                field => "cf_app_id"
+                destination => "cf_app_metadata_raw"
+            }
+            json {
+                source => 'cf_app_metadata_raw'
+                remove_field => [ "cf_app_metadata_raw", "cf_app_id_unknown" ]
             }
         
             #Ensure that we always have an event_type, in prep for adding metrics
@@ -89,7 +108,7 @@ properties:
             
       } else if [@type] in ["syslog", "relp"] and [@source.host] == "loggregator" {
         # Parse Cloud Foundry logs from loggregator (syslog)
-        # see https://github.      com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
+        # see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
         
         grok {
             match => { "syslog_procid" => "\[(?<log_source>[^/\]]+)(?:/(?<log_source_id>[^\]]+))?\]" }
@@ -195,4 +214,4 @@ properties:
         }
       
       }
-      
+

--- a/templates/logsearch/logstash-filters.yml
+++ b/templates/logsearch/logstash-filters.yml
@@ -2,7 +2,7 @@ properties:
   logstash_parser:
     filters: |
       <%=      # Parse Cloud Foundry logs from loggregator (syslog)
-      # see https://github.      com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
+      # see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
       
       if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
         # Parse Cloud Foundry logs from doppler (via https://github.com/SpringerPE/firehose-to-syslog)
@@ -29,7 +29,7 @@ properties:
             if ('RTR' in [source_type]) {
                 grok {
                     match => {
-                        'msg' => '%{HOSTNAME:hostname} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:verb} %{URIPATHPARAM:path} %{PROG:http_spec}\" %{BASE10NUM:status:int} %{BASE10NUM:body_bytes_sent:int} \"%{GREEDYDATA:referer}\" \"%{GREEDYDATA:http_user_agent}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:x_forwarded_for}\" vcap_request_id:%{NOTSPACE:vcap_request_id} response_time:%{NUMBER:response_time:float} app_id:%{NOTSPACE}'
+                        'msg' => '%{HOSTNAME:hostname} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:verb}       %{URIPATHPARAM:path} %{PROG:http_spec}\" %{BASE10NUM:status:int} %{BASE10NUM:body_bytes_sent:int}       \"%{GREEDYDATA:referer}\" \"%{GREEDYDATA:http_user_agent}\" %{HOSTPORT}       x_forwarded_for:\"%{GREEDYDATA:x_forwarded_for}\" vcap_request_id:%{NOTSPACE:vcap_request_id}       response_time:%{NUMBER:response_time:float} app_id:%{NOTSPACE}'
                         overwrite => [ "time" ]
                         'tag_on_failure' => [ 'fail/cloudfoundry/doppler/RTR' ]
                     }
@@ -58,6 +58,25 @@ properties:
                         remove => [ "msg" ]
                     }
                 }
+            }
+        
+            #EXPERIMENTAL: Decorate log event with app name / space / org metadata
+            translate {
+                #Lookup using: cf curl "/v2/apps/$APP_UUID?inline-relations-depth=2" | jq --compact-output '. | { cf_app_id: .metadata.guid,       cf_app_name: .entity.name , cf_space_id: .entity.space.metadata.guid , cf_space_name: .entity.space.entity.name , cf_org_id:       .entity.space.entity.organization.metadata.guid , cf_org_name: .entity.space.entity.organization.entity.name }'
+                dictionary => [ 
+                    'ec2d33f6-fd1c-49a5-9a90-031454d1f1ac', '{"cf_app_id":"ec2d33f6-fd1c-49a5-9a90-      031454d1f1ac","cf_app_name":"myappname","cf_space_id":"ec2d33f6-fd1c-49a5-9a90-      03145444444","cf_space_name":"myspacename","cf_org_id":"ec2d33f6-fd1c-49a5-9a90-      031454d555555","cf_org_name":"myorgname"}',
+                    'afc7d161-b5d5-44f2-a2c8-63870ff8f2db', '{"cf_app_id":"afc7d161-b5d5-44f2-a2c8-      63870ff8f2db","cf_app_name":"goexample","cf_space_id":"b1aa14ec-eaae-4e2c-804d-      08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}',
+                    'abfc9a95-d20c-44bb-9771-4aba27856843', '{"cf_app_id":"abfc9a95-d20c-44bb-9771-4aba27856843","cf_app_name":"cf-      env","cf_space_id":"b1aa14ec-eaae-4e2c-804d-08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-      e3a5db9419fd","cf_org_name":"system"}',
+                    'e6f78bd9-ca15-42d3-894e-d2b8b06e5e83', '{"cf_app_id":"e6f78bd9-ca15-42d3-894e-      d2b8b06e5e83","cf_app_name":"discourse","cf_space_id":"b1aa14ec-eaae-4e2c-804d-      08b2ae75a2bf","cf_space_name":"test","cf_org_id":"cbb84726-b20f-424f-b420-e3a5db9419fd","cf_org_name":"system"}'
+                
+                ]
+                fallback => '{"cf_app_id_unknown":"00000000-0000-0000-0000-000000000000","cf_app_name":"UNKNOWN","cf_space_id":"00000000-0000      -0000-0000-000000000000","cf_space_name":"UNKNOWN","cf_org_id":"00000000-0000-0000-0000-      000000000000","cf_org_name":"UNKNOWN"}'
+                field => "cf_app_id"
+                destination => "cf_app_metadata_raw"
+            }
+            json {
+                source => 'cf_app_metadata_raw'
+                remove_field => [ "cf_app_metadata_raw", "cf_app_id_unknown" ]
             }
         
             #Ensure that we always have an event_type, in prep for adding metrics
@@ -89,7 +108,7 @@ properties:
             
       } else if [@type] in ["syslog", "relp"] and [@source.host] == "loggregator" {
         # Parse Cloud Foundry logs from loggregator (syslog)
-        # see https://github.      com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
+        # see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
         
         grok {
             match => { "syslog_procid" => "\[(?<log_source>[^/\]]+)(?:/(?<log_source_id>[^\]]+))?\]" }
@@ -195,4 +214,4 @@ properties:
         }
       
       }
-      
+

--- a/templates/logsearch/properties.yml
+++ b/templates/logsearch/properties.yml
@@ -1,17 +1,31 @@
+meta:
+  skip-ssl-validation: (( merge || false ))
+  ingestor_cloudfoundry-firehose:
+    uaa-endpoint: (( merge ))
+    doppler-endpoint: (( merge ))
+    firehose-user: (( merge || "admin" ))
+    firehose-password: (( merge ))
+  api_host_header: (( merge ))
+  logstash_ingestor_syslog:
+    ssl_cert: (( merge ))
+    ssl_key: (( merge ))
+
 properties: 
   ingestor_cloudfoundry-firehose:
     debug: true
-    uua-endpoint: "https://uaa.run.54.183.203.97.xip.io/oauth/authorize"
-    doppler-endpoint: "wss://doppler.run.54.183.203.97.xip.io"
-    skip-ssl-validation: true
-    firehose-user: admin
-    firehose-password: c1oudc0wc1oudc0w
+    # Typo can be removed when fixed upstream
+    uua-endpoint: (( meta.ingestor_cloudfoundry-firehose.uaa-endpoint ))
+    uaa-endpoint: (( meta.ingestor_cloudfoundry-firehose.uaa-endpoint ))
+    doppler-endpoint: (( meta.ingestor_cloudfoundry-firehose.doppler-endpoint ))
+    skip-ssl-validation: (( meta.skip-ssl-validation ))
+    firehose-user: (( meta.ingestor_cloudfoundry-firehose.firehose-user ))
+    firehose-password: (( meta.ingestor_cloudfoundry-firehose.firehose-password ))
     syslog-server: "127.0.0.1:5514"
   api:
     port: 80
     kibana:
       port: 80
-      host_header: logs.54.183.203.97.xip.io
+      host_header: (( meta.api_host_header ))
       host: 127.0.0.1:5601
   kibana:
     elasticsearch: 127.0.0.1:9200
@@ -27,37 +41,5 @@ properties:
       port: 5514
     syslog_tls:
       port: 443
-      ssl_cert: |
-          -----BEGIN CERTIFICATE-----
-          MIICsDCCAhmgAwIBAgIJAJZZlYOII804MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
-          BAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX
-          aWRnaXRzIFB0eSBMdGQwHhcNMTQwNDA4MTUxNzA3WhcNMjQwNDA1MTUxNzA3WjBF
-          MQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50
-          ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
-          gQC2xI0wD26YOIEukuyokWDkKsFEvZxnadOEGT/9isf/mdiMk10NRZTF5bZU9ek9
-          Vj9HsO7sk2ays31bkjQVAw9/l2eQSDNKtnnWk28AiTEOvZq5ZYnc9PT5uyHQL4Uj
-          XJe2H8Dg/gfJhy9Ru9gpSSnRkYOXnwp2v6eJiQtzC6EG0QIDAQABo4GnMIGkMB0G
-          A1UdDgQWBBSyMMgqdi6u092zAgm03c0/JhP0bDB1BgNVHSMEbjBsgBSyMMgqdi6u
-          092zAgm03c0/JhP0bKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUt
-          U3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAJZZlYOI
-          I804MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEAif7W/VbSZ9GHfNDP
-          Cf+dsFTBk/1MpPW0cHXCX2lza42kbZ29PmhW1DSD+LkDcodL5wdVvTKSvJKmi5Cz
-          Y4O5DFyRcLQVTrhlUWfnUxTmaeWWzWyZe4RI98tTc2QHli6S9aeqczpa8k1aTiDp
-          XDPsPhpJjIepHXFRDaXUoV/T984=
-          -----END CERTIFICATE-----
-      ssl_key: |
-          -----BEGIN RSA PRIVATE KEY-----
-          MIICWwIBAAKBgQC2xI0wD26YOIEukuyokWDkKsFEvZxnadOEGT/9isf/mdiMk10N
-          RZTF5bZU9ek9Vj9HsO7sk2ays31bkjQVAw9/l2eQSDNKtnnWk28AiTEOvZq5ZYnc
-          9PT5uyHQL4UjXJe2H8Dg/gfJhy9Ru9gpSSnRkYOXnwp2v6eJiQtzC6EG0QIDAQAB
-          AoGASnrQmnw/cnLcWfFv1cXguTqfJfcrDI14r8VmaVkr5YJ5V9gZvHXVicvxwK+x
-          y9gg04NL6karPDme5TkwVju4DXJxwcT70QhFOG5EHFxij1HA8hgOU+K4X4FeNVbz
-          JPi27ktnJTsYs2Hq/UMoWygTvlTtyCsCytcAuo5jZRoy/cECQQDxoeFJiIH6hn2M
-          G/89USPeJKfiXIP8pSZCZi/FagVHRYKhgJ2MY4Uw4bmIxyiMO9VGSXhDpbnx1AAp
-          /6/KOod5AkEAwaKjDcI4c87DRQfPdORNBoKPTY1CuLgYUTIKBDUYUG0d/Vwy+USA
-          0NJI74B6sLCdfxLtK1d95XVuLRPDDGksGQJAMm0zI/JuFcdtegj5umUtlBWYR8BA
-          9z/L/T1wKMXYdihGe8fomTzHtgzVeHr/tkxiVPnONGfop1Qz+I/Yst6GGQJANAJ+
-          L1zikuCPfIQrieckdUIuQZNWv4zbIzwAir7EKB4W9w2Dt4ZZ3z0MUCA/VCQsOYyY
-          3ZJjg3V2QW9UbYn2SQJAMwhKLGhbuv5ge5K5H436Rl0NR2nZVaIgxez0Y8tVeTBT
-          rM8ETzoKmuLdiTl3uUhgJMtdOP8w7geYl8o1YP+3YQ==
-          -----END RSA PRIVATE KEY-----
+      ssl_cert: (( meta.logstash_ingestor_syslog.ssl_cert ))
+      ssl_key: (( meta.logstash_ingestor_syslog.ssl_key ))

--- a/templates/logsearch/properties.yml
+++ b/templates/logsearch/properties.yml
@@ -1,11 +1,21 @@
 properties: 
-  collectd:
-    hostname_prefix: "dev.logsearch.repo-test1."
-    python_librato:
-      #enabled: true
-      include_regex: "collectd\\.cpu\\..*,collectd\\.df\\..*,collectd\\.disk\\..*,collectd\\.elasticsearch\\..*,collectd\\.entropy\\..*,collectd\\.interface\\..*,collectd\\.load\\..*,collectd\\.memory\\..*,collectd\\.processes\\..*,collectd\\.redis_.*,collectd\\.users\\..*"
-      #email: nobody@example.com
-      #api_token: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  ingestor_cloudfoundry-firehose:
+    debug: true
+    uua-endpoint: "https://uaa.run.54.183.203.97.xip.io/oauth/authorize"
+    doppler-endpoint: "wss://doppler.run.54.183.203.97.xip.io"
+    skip-ssl-validation: true
+    firehose-user: admin
+    firehose-password: c1oudc0wc1oudc0w
+    syslog-server: "127.0.0.1:5514"
+  api:
+    port: 80
+    kibana:
+      port: 80
+      host_header: logs.54.183.203.97.xip.io
+      host: 127.0.0.1:5601
+  kibana:
+    elasticsearch: 127.0.0.1:9200
+    port: 5601 
   logstash_parser:
     debug: true
     filters: ~
@@ -18,41 +28,6 @@ properties:
     syslog_tls:
       port: 443
       ssl_cert: |
-          -----BEGIN CERTIFICATE-----
-          MIICsDCCAhmgAwIBAgIJAJZZlYOII804MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
-          BAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX
-          aWRnaXRzIFB0eSBMdGQwHhcNMTQwNDA4MTUxNzA3WhcNMjQwNDA1MTUxNzA3WjBF
-          MQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50
-          ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
-          gQC2xI0wD26YOIEukuyokWDkKsFEvZxnadOEGT/9isf/mdiMk10NRZTF5bZU9ek9
-          Vj9HsO7sk2ays31bkjQVAw9/l2eQSDNKtnnWk28AiTEOvZq5ZYnc9PT5uyHQL4Uj
-          XJe2H8Dg/gfJhy9Ru9gpSSnRkYOXnwp2v6eJiQtzC6EG0QIDAQABo4GnMIGkMB0G
-          A1UdDgQWBBSyMMgqdi6u092zAgm03c0/JhP0bDB1BgNVHSMEbjBsgBSyMMgqdi6u
-          092zAgm03c0/JhP0bKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUt
-          U3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAJZZlYOI
-          I804MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEAif7W/VbSZ9GHfNDP
-          Cf+dsFTBk/1MpPW0cHXCX2lza42kbZ29PmhW1DSD+LkDcodL5wdVvTKSvJKmi5Cz
-          Y4O5DFyRcLQVTrhlUWfnUxTmaeWWzWyZe4RI98tTc2QHli6S9aeqczpa8k1aTiDp
-          XDPsPhpJjIepHXFRDaXUoV/T984=
-          -----END CERTIFICATE-----
-      ssl_key: |
-          -----BEGIN RSA PRIVATE KEY-----
-          MIICWwIBAAKBgQC2xI0wD26YOIEukuyokWDkKsFEvZxnadOEGT/9isf/mdiMk10N
-          RZTF5bZU9ek9Vj9HsO7sk2ays31bkjQVAw9/l2eQSDNKtnnWk28AiTEOvZq5ZYnc
-          9PT5uyHQL4UjXJe2H8Dg/gfJhy9Ru9gpSSnRkYOXnwp2v6eJiQtzC6EG0QIDAQAB
-          AoGASnrQmnw/cnLcWfFv1cXguTqfJfcrDI14r8VmaVkr5YJ5V9gZvHXVicvxwK+x
-          y9gg04NL6karPDme5TkwVju4DXJxwcT70QhFOG5EHFxij1HA8hgOU+K4X4FeNVbz
-          JPi27ktnJTsYs2Hq/UMoWygTvlTtyCsCytcAuo5jZRoy/cECQQDxoeFJiIH6hn2M
-          G/89USPeJKfiXIP8pSZCZi/FagVHRYKhgJ2MY4Uw4bmIxyiMO9VGSXhDpbnx1AAp
-          /6/KOod5AkEAwaKjDcI4c87DRQfPdORNBoKPTY1CuLgYUTIKBDUYUG0d/Vwy+USA
-          0NJI74B6sLCdfxLtK1d95XVuLRPDDGksGQJAMm0zI/JuFcdtegj5umUtlBWYR8BA
-          9z/L/T1wKMXYdihGe8fomTzHtgzVeHr/tkxiVPnONGfop1Qz+I/Yst6GGQJANAJ+
-          L1zikuCPfIQrieckdUIuQZNWv4zbIzwAir7EKB4W9w2Dt4ZZ3z0MUCA/VCQsOYyY
-          3ZJjg3V2QW9UbYn2SQJAMwhKLGhbuv5ge5K5H436Rl0NR2nZVaIgxez0Y8tVeTBT
-          rM8ETzoKmuLdiTl3uUhgJMtdOP8w7geYl8o1YP+3YQ==
-          -----END RSA PRIVATE KEY-----
-    lumberjack:
-      ssl_certificate: |
           -----BEGIN CERTIFICATE-----
           MIICsDCCAhmgAwIBAgIJAJZZlYOII804MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
           BAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX


### PR DESCRIPTION
Updates to use logsearch v19 (pre-release) and logsearch-for-cloudfoundry addon v1
