### PR TITLE
Updated logstash filters addons url

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ namespace :addons do
   def addons
     {
       'logsearch-for-cloudfoundry' => {
-        logstash_filters: 'https://raw.githubusercontent.com/logsearch/logsearch-for-cloudfoundry/master/target/logstash-filters-default.conf'
+        logstash_filters: 'https://raw.githubusercontent.com/logsearch/logsearch-for-cloudfoundry/master/src/logsearch-config/target/logstash-filters-default.conf'
       } # ,
       # 'logsearch-for-websites' => {
       #    logstash_filters: 'https://raw.githubusercontent.com/logsearch/logsearch-for-websites/v0.5/target/logstash-filters-default.conf'


### PR DESCRIPTION
The logstash_filters addons url seems broken, this small fix should fix it.
